### PR TITLE
use python3 in skeleton yaml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # SkilletBuilder
 Docs, tools and tutorial for Skillet Building
 
-The main documentation provides generic manual instruction for template
-creation.
-
+The [Skillet Builder documentation](https://skilletbuilder.readthedocs.io/en/latest/reference_examples/builder_tools.html)
+provides detailed information for each builder tool.
 
 Using these tools, it is possible to manually configure a NGFW, then generate a skillet from those changes. That 
 skillet can then be used to configure N number of other NGFWs with some light editing to add variables. 

--- a/skeleton_yaml/.meta-cnc.yaml
+++ b/skeleton_yaml/.meta-cnc.yaml
@@ -49,8 +49,8 @@ variables:
         value: template
       - key: rest
         value: rest
-      - key: python
-        value: python
+      - key: python3
+        value: python3
       - key: terraform
         value: terraform
       - key: validation


### PR DESCRIPTION
Minor updates to the skeleton YAML file and README.md:

Use python3 as the skillet type for python in the skeleton yaml file

Update README.md with the skilletbuilder.readthedocs.io link