### PR TITLE
update with python3 type

### DIFF
--- a/docs/getting_started/skillet_framework.rst
+++ b/docs/getting_started/skillet_framework.rst
@@ -106,7 +106,7 @@ Snippets
     * panos/panorama: reads a list of XPaths and elements that are pushed to the device for configuration
     * template: simple rendering of a text file displayed to the screen
     * rest: a series of REST API interactions including response capture
-    * python: run a python script in a local virtual environment
+    * python3: run a python script in a local virtual environment
     * pan_validation: assess a configuration against a set of predefined rules
     * terraform: run terraform deployments for cloud deployments
     * docker: instantiate a docker container to run virtual applications

--- a/docs/reference_examples/skillet_types.rst
+++ b/docs/reference_examples/skillet_types.rst
@@ -152,11 +152,13 @@ pan_validation
 
 |
 
-python
-------
+python3
+-------
 
   Run python scripts within a controlled virtual environment and include a web UI
   instead of command line arguments. Designed to simplify sharing of python scripts.
+
+  Current version used in panHandler is python3.6
 
   Examples:
 


### PR DESCRIPTION
Minor update in the docs using type=python3 instead of python

Updated both the skillet types docs and the skillet framework listing the skillet types