### PR TITLE
Clean-Up Core Elements Sections

### DIFF
--- a/docs/building_blocks/jinja_and_skillets.rst
+++ b/docs/building_blocks/jinja_and_skillets.rst
@@ -237,3 +237,31 @@ Filters are used by including `` | filter `` after a variable:
 | var | int                                    |  convert a string to an integer                 |
 +----------------------------------------------+-------------------------------------------------+
 
+Jinja Whitespace Control
+------------------------
+
+Care must usually be taken to ensure no extra whitespace creeps into your templates due to Jinja looping
+constructs or control characters. For example, consider the following fragment:
+
+.. code-block:: jinja
+
+    <dns-servers>
+    {% for member in CLIENT_DNS_SUFFIX %}
+        <member>{{ member }}</member>
+    {% endfor %}
+    </dns-servers>
+
+This fragment will result in blank lines being inserted where the `for` and `endfor` control tags are placed. To
+ensure this does not happen and to prevent any unintentioal whitespace, you can use Jinja whitespace control like
+so:
+
+.. code-block:: jinja
+
+    <dns-servers>
+    {%- for member in CLIENT_DNS_SUFFIX %}
+        <member>{{ member }}</member>
+    {%- endfor %}
+    </dns-servers>
+
+.. note:: Note the '-' after the leading '{%'. This instructs jinja to remove these blank lines in the resulting
+    parsed output template.

--- a/docs/building_blocks/jinja_and_skillets.rst
+++ b/docs/building_blocks/jinja_and_skillets.rst
@@ -59,6 +59,26 @@ The skillet player captures the variable values with output as a rendered XML el
           <comments>block rules based on EDL destinations</comments>
         </entry>
 
+Ensuring All Variables Are Defined
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When working with a large amount of configuration templates, it's easy to miss a variable definition. Use this one-liner
+to find them all.
+
+Change directories into a skillet directory and run this to find all configured variables:
+
+.. code-block:: bash
+
+    grep -r '{{' . |  cut -d'{' -f3 | awk '{ print $1 }' | sort -u
+
+
+Or, if you have `perl` available, the following may also catch any configuration commands that may have
+more than one variable defined:
+
+.. code-block:: bash
+
+    grep -r '{{' . | perl -pne 'chomp(); s/.*?{{ (.*?) }}/$1\n/g;' | sort -u
+
 |
 
 Jinja If Conditional

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,6 @@ Skillet Builder Documentation
 
    getting_started/overview
    getting_started/skillet_framework
-   reference_examples/skillets
 
 .. toctree::
    :maxdepth: 1

--- a/docs/reference_examples/metadata_attributes.rst
+++ b/docs/reference_examples/metadata_attributes.rst
@@ -31,95 +31,104 @@ The preamble is the top section of the skillet providing identifying items, help
 
 name
 ~~~~
-    unique identifier for the skillet referenced by skillet tools and workflows
+    Globally unique identifier for the skillet referenced by skillet tools and workflows.
+
+    .. note::
+
+        The skillet name must not contain special characters such as '-' or '*' or spaces. Variable names can be any
+        length and can consist of uppercase and lowercase letters ( A-Z , a-z ), digits ( 0-9 ), and the underscore
+        character ( _ ). An additional restriction is that, although a variable name can contain digits, the first
+        character of a variable name cannot be a digit.
 
 label
 ~~~~~
-    short descriptive name identifying the skillet; shown in panHandler selection tiles
+    A short descriptive name identifying the skillet that is shown in PanHandler selection tiles.
 
 description
 ~~~~~~~~~~~
-    contextual description of the skillet presented to the user. May include quick caveats, reminders, and
+    A contextual description of the skillet presented to the user. This may include quick caveats, reminders, and
     skillet intent.
 
 type
 ~~~~
-    one of the predefined :ref:`Skillet Types` allowing tools to determine how to play the skillet
+    One of the predefined :ref:`Skillet Types` allowing tools to determine how to play the skillet.
 
 labels
 ~~~~~~
-    optional key/value pairs adding additional parameters that may not be implemented by all tools
-    see :ref:`Labels Attributes` for currently supported panHandler labels
+    Optional key/value pairs adding complimentary parameters that may not be implemented by all tools.
+    See :ref:`Labels Attributes` below for currently supported PanHandler labels.
 
 |
+------------------------------------------------------
 
 Labels Attributes
 -----------------
 
 Labels are key/value pairs attached to skillets. Labels are optional and allow adding additional parameters to Skillets
-that may not be implemented by all Tools. Labels can be used for grouping, searching, sorting, and identifying skillets
-beyond just a 'name' attribute. Labels can be used to extend Skillet functionality in arbitrary ways going forward. This
-behaviour is very much influenced by BGPv4 labels and Kubernetes labels.
+that may not be implemented by all utilities. Labels can be used for grouping, searching, sorting, and identifying skillets
+beyond just a **name** attribute. Labels can be used to extend Skillet functionality in arbitrary ways going forward. This
+behavior is very much influenced by BGPv4 labels and Kubernetes labels.
 
-Panhandler recognizes the following labels:
+PanHandler recognizes the following labels:
 
 collection
 ~~~~~~~~~~
 
-  The `collection` label is used to group like Skillets. A skillet may belong to multiple collections. The collection
-  label value is a list of collection to which the skillet belongs. Skillets with no `collection` label will be placed
-  in the *Unknown* Collection.
+    The **collection** label is used to group like skillets. A skillet may belong to multiple collections. The **collection**
+    label value is a list of collection to which the skillet belongs. Skillets with no **collection** label will be placed
+    in the *Unknown* Collection.
 
-.. code-block:: yaml
+    .. code-block:: yaml
 
-    labels:
-      collection:
-        - Example Skillets
-        - Test Skillets
-        - Validation Skillets
+        labels:
+          collection:
+            - Example Skillets
+            - Test Skillets
+            - Validation Skillets
 
 
 order
 ~~~~~
 
-  Panhandler uses the 'order' label to sort the Skillets. Skillets without an 'order' label are sorted alphabetically
-  by their 'label' attribute. Skillets with a lower 'order' tag will be display before those with a higher 'order' tag.
+    PanHandler uses the **order** label to sort the skillets. Skillets without an **order** label are sorted alphabetically
+    by their **label** attribute. Skillets with a lower **order** tag will be display before those with a higher **order** tag.
 
-.. code-block:: yaml
+    .. code-block:: yaml
 
-    labels:
-      order: 10
+        labels:
+          order: 10
 
 
 help_link
 ~~~~~~~~~
 
-  The `help_link` label can be used to display a link to additional documentation about a skillet. This will be shown
-  in the 'Help' dialog from the '?' icon in the top right hand corner of the Skillet input form.
+    The **help_link** label can be used to display a link to additional documentation about a skillet. This will be shown
+    in the *Help* dialog from the *?* icon in the top right hand corner of the skillet input form.
 
-.. code-block:: yaml
+    .. code-block:: yaml
 
-    labels:
-      help_link: https://panhandler.readthedocs.io/en/master/variables.html
+        labels:
+          help_link: https://panhandler.readthedocs.io/en/master/variables.html
 
 
 help_link_title
 ~~~~~~~~~~~~~~~
 
-  The `help_link_title` will set the displayed title of the `help_link` in the Help dialog.
+  The **help_link_title** will set the displayed title of the **help_link** in the Help dialog.
 
-.. code-block:: yaml
+    .. code-block:: yaml
 
-    labels:
-      help_link: https://panhandler.readthedocs.io/en/master/variables.html
-      help_link_title: All available Variable Documentation
+        labels:
+          help_link: https://panhandler.readthedocs.io/en/master/variables.html
+          help_link_title: All available Variable Documentation
 
 |
+------------------------------------------------------
 
 Variables Attributes
 --------------------
 
-The variables section is used to define variables and web UI attributes.
+The **variables** section is used to define variables and web UI attributes.
 
 .. code-block:: yaml
 
@@ -152,7 +161,7 @@ The variables section is used to define variables and web UI attributes.
 
 name
 ~~~~
-    name assigned to the variable
+    A name assigned to the variable.
 
     .. note::
 
@@ -163,147 +172,156 @@ name
 
 description
 ~~~~~~~~~~~
-    description of the variable usage and can be displayed as part of a web form
+    A description of the variable usage and can be displayed as part of a web form.
 
 default
 ~~~~~~~
-    default value of the variable; typically set to a recommended value
+    A default value of the variable, which is typically set to a recommended value.
 
 type_hint
 ~~~~~~~~~
-    type of variable and associates to web form validation; some variable types such as dropdown will
-    use additional key/value pairs or source options for user selection;
-    See :ref:`Variables` for a complete list of type_hints and dynamic UI elements
+    One of the predefined :ref:`variable types<Variables>` and associates to web form validation. Some variable types,
+    such as dropdown, will use additional key/value pairs or source options for user selection.
+    See :ref:`Variables` for a complete list of **type_hints** and dynamic UI elements.
 
 source
 ~~~~~~
-    used in lieu of static key/value pairs in type hints such as dropdown to dynamically create user selections;
-    See :ref:`variable_source` for details and examples
+    Used in lieu of static key/value pairs in type hints such as dropdown to dynamically create user selections.
+    See :ref:`variable_source` for details and examples.
 
 toggle_hint
 ~~~~~~~~~~~
-    show a field based on a reference field value; See :ref:`variable_toggle_hint` for details and examples
+    Shows a field based on a reference field value. See :ref:`variable_toggle_hint` for details and examples.
 
 |
+------------------------------------------------------
 
 Snippets Attributes
 -------------------
 
 name
 ~~~~
-    name of the snippet; for workflow reference the name of a skillet to play
+    Name of the snippet. Specifically for workflow type skillets, **name** references the Preamble **name** of a skillet
+    to play.
 
 cmd
 ~~~
-    command action to be performed; default and values vary by skillet type; :ref:`cmd Options` for details
+    Command action to be performed. The default and values vary by skillet type. See :ref:`cmd Options` for additional details.
 
 xpath
 ~~~~~
-    XPath used for set, edit, and delete cmd options (TODO: validate this content);
-    panos/panorama
+    The XPath used for *set*, *edit*, and *delete* **cmd** options for **panos/panorama**.
 
 element
 ~~~~~~~
-    XML element used for configuration; cmd = set or edit;
-    panos/panorama
+    The XML element used for *set*, *edit*, and *delete* **cmd** options for **panos/panorama**.
 
 file
 ~~~~
-    skillet file to be read; template file, python file
+    A skillet file to be read. This can either be a template file for **template** skillets, python file for
+    **python3** skillets, or an XML file for **panos/panorama** skillets.
 
 path
 ~~~~
-    URI path; REST
+    The URI path for **REST** skillets.
 
 operation
 ~~~~~~~~~
-    POST or GET operation; REST
+    The REST operation, either POST or GET, for **REST** skillets.
 
 headers
 ~~~~~~~
-    headers used as part of a REST API call; REST
+    The headers used as part of a REST API call in **REST** skillets.
 
 output_type
 ~~~~~~~~~~~
-    data format for response outputs
+    The data format for response outputs.
 
 outputs
 ~~~~~~~
-    outputs assigned to a variable; format is defined using :ref:`Capture Output` options
+    The outputs assigned to a variable. The format is defined using :ref:`Capture Output` options.
 
 input_type
 ~~~~~~~~~~
-    used in python skillets to specify method for parsing arguments
+    Used in **python3** skillets to specify method for parsing arguments.
 
 image
 ~~~~~
-    docker image type such as alpine
+    Docker image type, such as Alpine.
 
 label
 ~~~~~
-    description text associated to a test; validation
+    A descriptive text associated with a test in **validation** skillets.
 
 severity
 ~~~~~~~~
-    indicates user-defined severity for a test; validation
+    Indicates user-defined severity for a test in **validation** skillets.
 
 fail_message
 ~~~~~~~~~~~~
-    output message when a test fails; validation
+    The output message when a test fails in **validation** skillets.
 
 pass_message
 ~~~~~~~~~~~~
-    output message when a test passes; validation
+    The output message when a test passes in **validation** skillets.
 
 test
 ~~~~
-    boolean test to perform; validation
+    A Boolean logic test that is evaluated for **validation** skillets.
 
 documentation_link
 ~~~~~~~~~~~~~~~~~~
-    documentation reference associated to a test; validation
+    A documentation reference associated to a test in **validation** skillets.
 
 when
 ~~~~
-    conditional logic that only performs a test with when is True
+    A conditional logic that only performs a test with when is *True*.
+
+transform
+~~~~~~~~~
+    A dictionary that maps the output from one sub-skillet to the input of another in **workflow**
+    skillets. See the `skilletlib Workflow with Transform`_ example skillet for formatting help.
+
+    .. _skilletlib Workflow with Transform:https://github.com/PaloAltoNetworks/skilletlib/blob/master/example_skillets/workflow_transform/workflow_transform.skillet.yaml
+
 
 |
-
+------------------------------------------------------
 
 cmd Options
 -----------
 
 set
 ~~~
-    merge element into the candidate configuration; panos/panorama
+    Merges element into the candidate configuration for **panos/panorama** skillets.
 
 edit
 ~~~~
-    replace configuration element with new element; panos/panorama
+    Replaces configuration element with new element for **panos/panorama** skillets.
 
 delete
 ~~~~~~
-    delete part of the configuration; panos/panorama
+    Deletes part of the configuration for **panos/panorama** skillets.
 
 get
 ~~~
-    pull information from a device; panos/panorama
+    Pulls information from a device for **panos/panorama** skillets.
 
 move
 ~~~~
-    move a configuration element; panos/panorama
+    Moves a configuration element for **panos/panorama** skillets.
 
 parse
 ~~~~~
-    parse an input file; all???
+    Parses an input file.
 
 cli
 ~~~
-    run an operations CLI commands such as 'show system info'; panos/panorama/validation
+    Run an operations CLI commands such as ``show system info`` for **panos/panorama/validation** skillets.
 
 validate
 ~~~~~~~~
-    run a validation test; validation
+    Run a validation test for **validation** skillets.
 
 validate_xml
 ~~~~~~~~~~~~
@@ -315,9 +333,88 @@ noop
 
 custom inputs
 ~~~~~~~~~~~~~
-    in this case instead of a cmd option, the skillet includes a command line string; eg ansible playbook command
+    In this case instead of a **cmd** option, the skillet includes a command line string, such as ``ansible playbook command``.
 
 
+|
+------------------------------------------------------
 
+Snippet Attributes per Skillet Type
+-----------------------------------
+
+Below describes the fields for a snippet depending on the skillet type:
+
+    * **docker**
+
+        * **name** - name of this snippet
+        * **image** - Docker image to run
+        * **cmd** - the command to run inside of the Docker container
+        * **when** - (Optional) conditional logic for snippets execution
+
+    * **panos**, **panorama**, **panorama-gpcs**
+
+        * **name** - name of this snippet
+        * **cmd** - operation to perform. Default is ``set``. See the :ref:`cmd Options` for all available options.
+        * **xpath** - XPath where this fragment belongs
+        * **file** - path to the XML fragment to load and parse. Interchangeable with element
+        * **element** - inline XML fragment to load and parse. Interchangeable with file
+        * **when** - (Optional) conditional logic for snippets execution
+
+        See Example here: :ref:`example_panos`
+
+    * **pan_validation**
+
+        * **name** - name of the validation test to perform
+        * **cmd** - validate, validate_xml, noop, or parse. Default is validate
+        * **test** - Boolean test to perform using Jinja2 expressions
+        * **when** - (Optional) conditional logic for snippets execution
+
+        See Example here: :ref:`example_validation`
+
+    * **python3**
+
+        * **name** - name of the script to execute
+        * **file** - relative path to the python script to execute
+        * **input_type** - Optional type of input required for this script. Valid options are 'cli' or 'env'.
+          This will determine how user input variables will be passed into into the script. The default is **cli** and will
+          pass variables as long form arguments to the script in the form of ``--username=user_input`` where ``username``
+          is the name of the variable defined in the **variables** section and ``user_input`` is the value entered for
+          that variable from the user. The other option, **env**, requires all defined variables to be set in the environment
+          of the python process.
+        * **when** - (Optional) conditional logic for snippets execution
+
+        See Example here: :ref:`example_python`
+
+    * **rest**
+
+        * **name** - unique name for this rest operation
+        * **path** - REST URL path component ``path: http://host/api/?type=keygen&user={{ username }}&password={{ password }}``
+        * **operation** - type of REST operation (GET, POST, DELETE, etc)
+        * **payload** - path to a Jinja2 template to load and parse to be send as POSTed payload. For ``x-www-form-urlencded``,
+          this must be a json dictionary
+        * **headers** - a dict of key value pairs to add to the http headers. For example, ``Content-Type: application/json``.
+        * **when** - (Optional) conditional logic for snippets execution
+
+        See Example here: :ref:`example_rest` and here: :ref:`example_rest_with_output`
+
+    * **template**
+
+        * **name** - name of this snippet
+        * **file** - path to the Jinja2 template to load and parse
+        * **template_title** - (Optional) title to include in rendered output
+        * **when** - (Optional) conditional logic for snippets execution
+
+    * **terraform**
+
+        * None - snippets are not used for terraform
+
+        See Example here: :ref:`example_terraform`
+
+    * **workflow**
+
+        * **name** - name of this sub-skillet to play
+        * **when** - (Optional) conditional logic for sub-skillet execution
+        * **transform** - (Optional) mapping of another snippet's output variable to this
+          snippet's input variable.
 
 

--- a/docs/reference_examples/metadata_attributes.rst
+++ b/docs/reference_examples/metadata_attributes.rst
@@ -53,6 +53,68 @@ labels
 
 |
 
+Labels Attributes
+-----------------
+
+Labels are key/value pairs attached to skillets. Labels are optional and allow adding additional parameters to Skillets
+that may not be implemented by all Tools. Labels can be used for grouping, searching, sorting, and identifying skillets
+beyond just a 'name' attribute. Labels can be used to extend Skillet functionality in arbitrary ways going forward. This
+behaviour is very much influenced by BGPv4 labels and Kubernetes labels.
+
+Panhandler recognizes the following labels:
+
+collection
+~~~~~~~~~~
+
+  The `collection` label is used to group like Skillets. A skillet may belong to multiple collections. The collection
+  label value is a list of collection to which the skillet belongs.
+
+.. code-block:: yaml
+
+    labels:
+      collection:
+        - Example Skillets
+        - Test Skillets
+        - Validation Skillets
+
+
+order
+~~~~~
+
+  Panhandler uses the 'order' label to sort the Skillets. Skillets without an 'order' label are sorted alphabetically
+  by their 'label' attribute. Skillets with a lower 'order' tag will be display before those with a higher 'order' tag.
+
+.. code-block:: yaml
+
+    labels:
+      order: 10
+
+
+help_link
+~~~~~~~~~
+
+  The `help_link` label can be used to display a link to additional documentation about a skillet. This will be shown
+  in the 'Help' dialog from the '?' icon in the top right hand corner of the Skillet input form.
+
+.. code-block:: yaml
+
+    labels:
+      help_link: https://panhandler.readthedocs.io/en/master/variables.html
+
+
+help_link_title
+~~~~~~~~~~~~~~~
+
+  The `help_link_title` will set the displayed title of the `help_link` in the Help dialog.
+
+.. code-block:: yaml
+
+    labels:
+      help_link: https://panhandler.readthedocs.io/en/master/variables.html
+      help_link_title: All available Variable Documentation
+
+|
+
 Variables Attributes
 --------------------
 
@@ -199,67 +261,6 @@ when
 
 |
 
-Labels Attributes
------------------
-
-Labels are key/value pairs attached to skillets. Labels are optional and allow adding additional parameters to Skillets
-that may not be implemented by all Tools. Labels can be used for grouping, searching, sorting, and identifying skillets
-beyond just a 'name' attribute. Labels can be used to extend Skillet functionality in arbitrary ways going forward. This
-behaviour is very much influenced by BGPv4 labels and Kubernetes labels.
-
-Panhandler recognizes the following labels:
-
-collection
-~~~~~~~~~~
-
-  The `collection` label is used to group like Skillets. A skillet may belong to multiple collections. The collection
-  label value is a list of collection to which the skillet belongs.
-
-.. code-block:: yaml
-
-    labels:
-      collection:
-        - Example Skillets
-        - Test Skillets
-        - Validation Skillets
-
-
-order
-~~~~~
-
-  Panhandler uses the 'order' label to sort the Skillets. Skillets without an 'order' label are sorted alphabetically
-  by their 'label' attribute. Skillets with a lower 'order' tag will be display before those with a higher 'order' tag.
-
-.. code-block:: yaml
-
-    labels:
-      order: 10
-
-
-help_link
-~~~~~~~~~
-
-  The `help_link` label can be used to display a link to additional documentation about a skillet. This will be shown
-  in the 'Help' dialog from the '?' icon in the top right hand corner of the Skillet input form.
-
-.. code-block:: yaml
-
-    labels:
-      help_link: https://panhandler.readthedocs.io/en/master/variables.html
-
-
-help_link_title
-~~~~~~~~~~~~~~~
-
-  The `help_link_title` will set the displayed title of the `help_link` in the Help dialog.
-
-.. code-block:: yaml
-
-    labels:
-      help_link: https://panhandler.readthedocs.io/en/master/variables.html
-      help_link_title: All available Variable Documentation
-
-|
 
 cmd Options
 -----------

--- a/docs/reference_examples/metadata_attributes.rst
+++ b/docs/reference_examples/metadata_attributes.rst
@@ -67,7 +67,8 @@ collection
 ~~~~~~~~~~
 
   The `collection` label is used to group like Skillets. A skillet may belong to multiple collections. The collection
-  label value is a list of collection to which the skillet belongs.
+  label value is a list of collection to which the skillet belongs. Skillets with no `collection` label will be placed
+  in the *Unknown* Collection.
 
 .. code-block:: yaml
 
@@ -152,6 +153,13 @@ The variables section is used to define variables and web UI attributes.
 name
 ~~~~
     name assigned to the variable
+
+    .. note::
+
+        The variable name must not contain special characters such as '-' or '*' or spaces. Variable names can be any
+        length and can consist of uppercase and lowercase letters ( A-Z , a-z ), digits ( 0-9 ), and the underscore
+        character ( _ ). An additional restriction is that, although a variable name can contain digits, the first
+        character of a variable name cannot be a digit.
 
 description
 ~~~~~~~~~~~

--- a/docs/reference_examples/skillet_types.rst
+++ b/docs/reference_examples/skillet_types.rst
@@ -10,29 +10,29 @@ validation, operations, and other needs beyond configuration.
 docker
 ------
 
-  With a docker skillet you can use any available libraries in the docker image.
-  This allows you to distribute custom tools and scripts, or use existing
-  dockerized tools, as a skillet.
+    With a **docker** skillet, you can use any available libraries in the Docker image.
+    This allows you to distribute custom tools and scripts, or use existing
+    dockerized tools, as a skillet.
 
-  Using a docker skillet, you can create a single docker image that contains
-  all your dependencies and distribute that with the Skillet metadata file.
+    Using a **docker skillet**, you can create a single Docker image that contains
+    all your dependencies and distribute that with the Skillet metadata file.
 
-  Use cases:
+    Use cases:
 
-    * Ansible playbooks and associated libraries
-    * Terraform implementations
-    * shell and python scripts
+        * Ansible playbooks and associated libraries
+        * Terraform implementations
+        * Shell and Python scripts
 
 
-  **View examples of docker skillets**
+    **View examples of docker skillets**
 
-  +---------------------------------------------------+
-  | `Prisma Access stage 1 configuration`_            |
-  +---------------------------------------------------+
-  | `Sample docker skillets`_                         |
-  +---------------------------------------------------+
-  | `Docker Skillets at the Skillet District`_        |
-  +---------------------------------------------------+
+    +---------------------------------------------------+
+    | `Prisma Access stage 1 configuration`_            |
+    +---------------------------------------------------+
+    | `Sample docker skillets`_                         |
+    +---------------------------------------------------+
+    | `Docker Skillets at the Skillet District`_        |
+    +---------------------------------------------------+
 
     .. _Prisma Access stage 1 configuration: https://github.com/PaloAltoNetworks/prisma-access-skillets/tree/master/configuration/stage_1_configuration
     .. _Sample docker skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/docker
@@ -44,266 +44,266 @@ docker
 panorama
 --------
 
-  Used for API-based XML configuration and operational interactions with Panorama.
+    Used for API-based XML configuration and operational interactions with Panorama.
 
-  Examples:
+    Examples:
 
-    * push XML configuration snippets that merge into the candidate configuration
-    * operational commands to generate certificates or perform 'load config partial'
-    * configuration commands for move, edit, and delete
+        * Push XML configuration snippets that merge into the candidate configuration
+        * Operational commands to generate certificates or perform `load config partial`
+        * Configuration commands for move, edit, and delete
 
-  **View examples of panorama skillets**
+    **View examples of panorama skillets**
 
-  +---------------------------------------------------+
-  | `IronSkillet v9.1 Panorama`_                      |
-  +---------------------------------------------------+
-  | `Panorama Skillets at the Skillet District`_      |
-  +---------------------------------------------------+
+    +---------------------------------------------------+
+    | `IronSkillet v9.1 Panorama`_                      |
+    +---------------------------------------------------+
+    | `Panorama Skillets at the Skillet District`_      |
+    +---------------------------------------------------+
 
-  .. _IronSkillet v9.1 Panorama: https://github.com/PaloAltoNetworks/iron-skillet/tree/panos_v9.0/templates/panos/snippets
-  .. _Panorama Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/panorama
+    .. _IronSkillet v9.1 Panorama: https://github.com/PaloAltoNetworks/iron-skillet/tree/panos_v9.0/templates/panos/snippets
+    .. _Panorama Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/panorama
 
 
-  .. NOTE::
-      The panos and panorama types are functionally identical and used primarily to denote
-      the platform target for the skillet
+    .. NOTE::
+        The **panos** and **panorama** types are functionally identical and used primarily to denote
+        the platform target for the skillet.
 
-  .. NOTE::
-      The panorama and panorama-gpcs [Prisma Access] skillet types are identical except for tool
-      handling of the commit models. The panorama type will only commit to Panorama while the
-      panorama-gpcs type will also push the configuration to Prisma Access.
+    .. NOTE::
+        The **panorama** and **panorama-gpcs** [Prisma Access] skillet types are identical, except for tool
+        handling of the commit models. The **panorama** type will only commit to Panorama while the
+        **panorama-gpcs** type will also push the configuration to Prisma Access.
 
 |
 
 panorama-gpcs
 -------------
 
-  Used for API-based XML configuration and operational interactions with Panorama specific
-  to Prisma Access plug-in configurations.
+    Used for API-based XML configuration and operational interactions with Panorama specific
+    to Prisma Access plug-in configurations.
 
-  Examples:
+    Examples:
 
-    * standard Panorama configuration for templates, template-stacks, and device-groups
-    * plug-in configuration for service connections, remote networks, and mobile users
+        * Standard Panorama configuration for templates, template-stacks, and device-groups
+        * Plug-in configuration for service connections, remote networks, and mobile users
 
-  **View examples of Prisma Access skillets**
+    **View examples of Prisma Access skillets**
 
-  +---------------------------------------------------+
-  | `Prisma Access Remote Network`_                   |
-  +---------------------------------------------------+
+    +---------------------------------------------------+
+    | `Prisma Access Remote Network`_                   |
+    +---------------------------------------------------+
 
-  .. _Prisma Access Remote Network: https://github.com/PaloAltoNetworks/prisma-access-skillets/tree/master/configuration/stage_2_configuration/remote_network_onboarding
+    .. _Prisma Access Remote Network: https://github.com/PaloAltoNetworks/prisma-access-skillets/tree/master/configuration/stage_2_configuration/remote_network_onboarding
 
 |
 
 panos
 -----
 
-  Used for API-based XML configuration and operational interactions with a PAN-OS NGFW.
+    Used for API-based XML configuration and operational interactions with a PAN-OS NGFW.
 
-  Examples:
+    Examples:
 
-    * push XML configuration snippets that merge into the candidate configuration
-    * operational commands to generate certificates or perform 'load config partial'
-    * configuration commands for move, edit, and delete
+        * Push XML configuration snippets that merge into the candidate configuration
+        * Operational commands to generate certificates or perform 'load config partial'
+        * Configuration commands for move, edit, and delete
 
 
-  **View examples of panos skillets**
+    **View examples of panos skillets**
 
-  +---------------------------------------------------+
-  | `Sample panos skillets`_                          |
-  +---------------------------------------------------+
-  | `IronSkillet v9.1 PAN-OS`_                        |
-  +---------------------------------------------------+
-  | `NGFW Skillets at the Skillet District`_          |
-  +---------------------------------------------------+
+    +---------------------------------------------------+
+    | `Sample panos skillets`_                          |
+    +---------------------------------------------------+
+    | `IronSkillet v9.1 PAN-OS`_                        |
+    +---------------------------------------------------+
+    | `NGFW Skillets at the Skillet District`_          |
+    +---------------------------------------------------+
 
-  .. _Sample panos skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/panos
-  .. _IronSkillet v9.1 PAN-OS: https://github.com/PaloAltoNetworks/iron-skillet/tree/panos_v9.0/templates/panos/snippets
-  .. _NGFW Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/ngfw
+    .. _Sample panos skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/panos
+    .. _IronSkillet v9.1 PAN-OS: https://github.com/PaloAltoNetworks/iron-skillet/tree/panos_v9.0/templates/panos/snippets
+    .. _NGFW Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/ngfw
 
 |
 
 pan_validation
 --------------
 
-  Used to capture and parse XML configuration file and operational command outputs and
-  match against a set of boolean test rules.
+    Used to capture and parse XML configuration file and operational command outputs and
+    match against a set of Boolean test rules.
 
-  Examples:
+    Examples:
 
-    * best practice configuration assessments (eg. IronSkillet)
-    * dependency checks before loading configuration skillets
-    * check for potential merge conflicts based on existing config elements
-    * troubleshooting assistance with config/system insights
+        * Best practice configuration assessments (eg. IronSkillet)
+        * Dependency checks before loading configuration skillets
+        * Check for potential merge conflicts based on existing config elements
+        * Troubleshooting assistance with config/system insights
 
-  **View examples of template skillets**
+    **View examples of template skillets**
 
-  +---------------------------------------------------+
-  | `Iron Skillet v9.1 validations`_                  |
-  +---------------------------------------------------+
-  | `Sample validation skillets`_                     |
-  +---------------------------------------------------+
-  | `Validation Skillets at the Skillet District`_    |
-  +---------------------------------------------------+
+    +---------------------------------------------------+
+    | `Iron Skillet v9.1 validations`_                  |
+    +---------------------------------------------------+
+    | `Sample validation skillets`_                     |
+    +---------------------------------------------------+
+    | `Validation Skillets at the Skillet District`_    |
+    +---------------------------------------------------+
 
-  .. _Iron Skillet v9.1 validations: https://github.com/PaloAltoNetworks/iron-skillet/tree/panos_v9.0/validations
-  .. _Sample validation skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/validation
-  .. _Validation Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/validation
+    .. _Iron Skillet v9.1 validations: https://github.com/PaloAltoNetworks/iron-skillet/tree/panos_v9.0/validations
+    .. _Sample validation skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/validation
+    .. _Validation Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/validation
 
 |
 
 python3
 -------
 
-  Run python scripts within a controlled virtual environment and include a web UI
-  instead of command line arguments. Designed to simplify sharing of python scripts.
+    Run Python scripts within a controlled virtual environment and include a web UI
+    instead of command line arguments. Designed to simplify sharing of Python scripts.
 
-  Current version used in panHandler is python3.6
+    Current version used in PanHandler is `python3.6`
 
-  Examples:
+    Examples:
 
-    * perform content updates
-    * use the NGFW and Support APIs to generate an SLR
-    * generate and import configuration files to a device
-
-
-  **View examples of python skillets**
-
-  +---------------------------------------------------+
-  | `HomeSkillet content updates`_                    |
-  +---------------------------------------------------+
-  | `Sample python skillets`_                         |
-  +---------------------------------------------------+
-  | `Python Skillets at the Skillet District`_        |
-  +---------------------------------------------------+
-
-  .. _HomeSkillet content updates: https://github.com/PaloAltoNetworks/HomeSkillet/tree/master/python_content_updates
-  .. _Sample python skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/python
-  .. _Python Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/python
+        * Perform content updates
+        * Use the NGFW and Support APIs to generate an SLR
+        * Generate and import configuration files to a device
 
 
-  .. NOTE::
-      Python scripts are useful when checking system state is required.
-      The best example is checking job status for a process before performing
-      the next task. Some skillets are stateless and do not have this capability.
+    **View examples of python skillets**
+
+    +---------------------------------------------------+
+    | `HomeSkillet content updates`_                    |
+    +---------------------------------------------------+
+    | `Sample python skillets`_                         |
+    +---------------------------------------------------+
+    | `Python Skillets at the Skillet District`_        |
+    +---------------------------------------------------+
+
+    .. _HomeSkillet content updates: https://github.com/PaloAltoNetworks/HomeSkillet/tree/master/python_content_updates
+    .. _Sample python skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/python
+    .. _Python Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/python
+
+
+    .. NOTE::
+        Python scripts are useful when checking system state is required.
+        The best example is checking job status for a process before performing
+        the next task. Some skillets are stateless and do not have this capability.
 
 |
 
 rest
 ----
 
-  General purpose REST interactions with any REST-supported API. View full results or
-  capture to use as input variables in other skillets.
+    General purpose REST interactions with any REST-supported API. Used to view full results or
+    to capture to use as input variables in other skillets.
 
-  Examples:
+    Examples:
 
-    * Prisma Access or other platform service information
-    * query a device and return a list of values used in a skillet UI dropdown
-    * check status of cloud platforms
+        * Prisma Access or other platform service information
+        * Query a device and return a list of values used in a skillet UI dropdown
+        * Check status of cloud platforms
 
-  **View examples of rest skillets**
+    **View examples of rest skillets**
 
-  +---------------------------------------------------+
-  | `Sample REST skillets`_                           |
-  +---------------------------------------------------+
-  | `HomeSkillet get zone names`_                     |
-  +---------------------------------------------------+
-  | `Prisma Access get service information`_          |
-  +---------------------------------------------------+
-  |  `REST Skillets at the Skillet District`_         |
-  +---------------------------------------------------+
+    +---------------------------------------------------+
+    | `Sample REST skillets`_                           |
+    +---------------------------------------------------+
+    | `HomeSkillet get zone names`_                     |
+    +---------------------------------------------------+
+    | `Prisma Access get service information`_          |
+    +---------------------------------------------------+
+    |  `REST Skillets at the Skillet District`_         |
+    +---------------------------------------------------+
 
-  .. _Sample REST skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/rest
-  .. _HomeSkillet get zone names: https://github.com/PaloAltoNetworks/HomeSkillet/tree/panos_v9.0/rest_get_zone_names
-  .. _Prisma Access get service information: https://github.com/PaloAltoNetworks/prisma-access-skillets/tree/master/assess/get_service_info
-  .. _REST Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/rest
+    .. _Sample REST skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/rest
+    .. _HomeSkillet get zone names: https://github.com/PaloAltoNetworks/HomeSkillet/tree/panos_v9.0/rest_get_zone_names
+    .. _Prisma Access get service information: https://github.com/PaloAltoNetworks/prisma-access-skillets/tree/master/assess/get_service_info
+    .. _REST Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/rest
 
 |
 
 template
 --------
 
-  This general purpose skillet type takes a text file input and renders output to screen
-  after variable substitutions.
+    This general purpose skillet type takes a text file input and renders output to screen
+    after variable substitutions.
 
-  Examples:
+    Examples:
 
-    * full XML config file generation for manual imports
-    * set command outputs
-    * 3rd party text file generation as reference configurations
-    * skillet workflow messaging outputs
+        * Full XML config file generation for manual imports
+        * Set command outputs
+        * Third party text file generation as reference configurations
+        * Skillet workflow messaging outputs
 
-  **View examples of template skillets**
+    **View examples of template skillets**
 
-  +---------------------------------------------------+
-  | `Iron Skillet v9.1 set commands`_                 |
-  +---------------------------------------------------+
-  | `Iron Skillet v9.1 XML config file`_              |
-  +---------------------------------------------------+
-  | `Sample template skillets`_                       |
-  +---------------------------------------------------+
-  | `Template Skillets at the Skillet District`_      |
-  +---------------------------------------------------+
+    +---------------------------------------------------+
+    | `Iron Skillet v9.1 set commands`_                 |
+    +---------------------------------------------------+
+    | `Iron Skillet v9.1 XML config file`_              |
+    +---------------------------------------------------+
+    | `Sample template skillets`_                       |
+    +---------------------------------------------------+
+    | `Template Skillets at the Skillet District`_      |
+    +---------------------------------------------------+
 
-  .. _Iron Skillet v9.1 set commands: https://github.com/PaloAltoNetworks/iron-skillet/tree/panos_v9.0/templates/panos/set_commands
-  .. _Iron Skillet v9.1 XML config file: https://github.com/PaloAltoNetworks/iron-skillet/tree/panos_v9.0/templates/panos/full
-  .. _Sample template skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/template/template_example
-  .. _Template Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/template
+    .. _Iron Skillet v9.1 set commands: https://github.com/PaloAltoNetworks/iron-skillet/tree/panos_v9.0/templates/panos/set_commands
+    .. _Iron Skillet v9.1 XML config file: https://github.com/PaloAltoNetworks/iron-skillet/tree/panos_v9.0/templates/panos/full
+    .. _Sample template skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/template/template_example
+    .. _Template Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/template
 
 |
 
 terraform
 ---------
 
-  Used in conjunction with terraform templates to deploy devices.
+    Used in conjunction with Terraform templates to deploy devices.
 
-  Examples:
+    Examples:
 
-    * deploy generic compute resources a public cloud
-    * deploy a VM-series or Panorama in the public cloud
+        * Deploy generic compute resources a public cloud
+        * Deploy a VM-series or Panorama in the public cloud
 
 
-  **View examples of terraform skillets**
+    **View examples of terraform skillets**
 
-  +---------------------------------------------------+
-  | `Deploy Panorama in Azure`_                       |
-  +---------------------------------------------------+
-  | `Sample Terraform skillets`_                      |
-  +---------------------------------------------------+
-  | `Terraform Skillets at the Skillet District`_     |
-  +---------------------------------------------------+
+    +---------------------------------------------------+
+    | `Deploy Panorama in Azure`_                       |
+    +---------------------------------------------------+
+    | `Sample Terraform skillets`_                      |
+    +---------------------------------------------------+
+    | `Terraform Skillets at the Skillet District`_     |
+    +---------------------------------------------------+
 
-  .. _Deploy Panorama in Azure: https://github.com/PaloAltoNetworks/prisma-access-skillets/tree/master/deploy/azure/deploy_panorama
-  .. _Sample Terraform skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/terraform
-  .. _Terraform Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/terraform
+    .. _Deploy Panorama in Azure: https://github.com/PaloAltoNetworks/prisma-access-skillets/tree/master/deploy/azure/deploy_panorama
+    .. _Sample Terraform skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/terraform
+    .. _Terraform Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/terraform
 
 |
 
 workflow
 --------
 
-  Run a series of skillets across various configurations or skillet types.
+    Run a series of skillets across various configurations or skillet types.
 
-  Examples:
+    Examples:
 
-    * query a device for attribute names then use in a configuration skillet
-    * load a series of day one, network, and policy skillets based on user inputs
-    * perform content updates before loading configuration elements
-    * validation dependencies before loading configuration elements
+        * Query a device for attribute names then use in a configuration skillet
+        * Load a series of day one, network, and policy skillets based on user inputs
+        * Perform content updates before loading configuration elements
+        * Validation dependencies before loading configuration elements
 
 
-  **View examples of workflow skillets**
+    **View examples of workflow skillets**
 
-  +---------------------------------------------------+
-  | `HomeSkillet workflow`_                           |
-  +---------------------------------------------------+
-  | `Sample workflow skillets`_                       |
-  +---------------------------------------------------+
-  | `Workflow Skillets at the Skillet District`_      |
-  +---------------------------------------------------+
+    +---------------------------------------------------+
+    | `HomeSkillet workflow`_                           |
+    +---------------------------------------------------+
+    | `Sample workflow skillets`_                       |
+    +---------------------------------------------------+
+    | `Workflow Skillets at the Skillet District`_      |
+    +---------------------------------------------------+
 
-  .. _HomeSkillet workflow: https://github.com/PaloAltoNetworks/HomeSkillet/tree/panos_v9.0/workflow_HomeSkillet_menu_selection
-  .. _Sample workflow skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/workflow
-  .. _Workflow Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/workflow
+    .. _HomeSkillet workflow: https://github.com/PaloAltoNetworks/HomeSkillet/tree/panos_v9.0/workflow_HomeSkillet_menu_selection
+    .. _Sample workflow skillets: https://github.com/PaloAltoNetworks/Skillets/tree/master/workflow
+    .. _Workflow Skillets at the Skillet District: https://live.paloaltonetworks.com/t5/Community-Skillets/tkb-p/Community_Skillets_Articles/label-name/workflow
 

--- a/docs/reference_examples/skillets.rst
+++ b/docs/reference_examples/skillets.rst
@@ -1,3 +1,6 @@
+.. This page is outdated and very specific to PanHandler. Information from this page that was not already in the SkilletBuilder
+    documentation was added to different sections.
+
 Skillets Defined
 ================
 


### PR DESCRIPTION
## Description

- Edited navigation bar to remove _Skillets Defined_ section
- Syntax and grammar check of `skillet_types.rst` and `metadata_attributes.rst`
- Moved **Snippets Attributes Required per Skillet Type** section from _Skillets Defined_ to _Metadata Attributes_ 
- Moved **Ensuring All Variables Are Defined** section from _Skillets Defined_ to _Jinja and Skillets_
- Moved **Jinja Whitespace Control** section from _Skillets Defined_ to _Jinja and Skillets_

## Motivation and Context

The _Skillets Defined_ section of the SkilletBuilder documentation was copied from the PanHandler readthedocs without regard to its formatting/repetition of other content. 

## How Has This Been Tested?

I ran this locally by rendering the html from the RST files.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
