### PR TITLE
Update Workflow Skillet Links to Documentation

### DIFF
--- a/sample_workflow_skillet/README.md
+++ b/sample_workflow_skillet/README.md
@@ -1,30 +1,62 @@
 # Sample Workflow Skillet
 
-This is used in the training material as part of the tutorial.
+This is used in the training material as part of the Workflow tutorial.
 
-The solution utilizes two skillets -- one for validating a running configuration and 
-one for configuring the following components: 
+The solution utilizes three skillets:
 
-* tag: create a tag using inputs for name, description, and color
-* external-list: create an edl using inputs for name, description, and url
-* security policies: inbound and outbound security policies referencing the edl and tag names
+1. A validation skillet to verify the running configuration
+2. A configuration skillet to configure:
+    * tag: create a tag using inputs for name, description, and color
+    * external-list: create an edl using inputs for name, description, and url
+    * security policies: inbound and outbound security policies referencing the edl and tag names
+3. A template skillet to output the workflow end
 
-## variables
+The configuration skillet was taken from the Configuration Tutorial for Skillet Builder documentation 
+(https://skilletbuilder.readthedocs.io/en/latest/tutorials/tutorial_configuration.html#).
 
-tag_name: name of a newly created tag and used in the security rules
-tag_description: text field to describe the tag
-tag_color: dropdown mapping color names to color numbers (required in the xml configuration)
+## Workflow Sequence 
 
-edl_name: name of the newly created external-list
-edl_description: text field used to describe the external-list
-edl_url: url used for the external-list
+This workflow skillet begins by prompting the user to input the workflow menu options, described below.
 
-The 'recurring' value for the EDL is set to five-minutes. This could be added as a variable but for this example, the
+Depending on the *assess_options* result, a validation skillet will be run next to verify that an 
+External Dynamic List object is configured for the *edl_url* inputted by the user. In addition,
+it will validate that two security policies exist denying traffic from and to the EDL object. 
+
+Next, the workflow prompts the user to fill in forms about the EDL and tag information. With this information, 
+the automation pushes a configuration that creates a tag object, EDL object, and two security policies. 
+
+Again, depending on the *assess_options* result, the same validation skillet will be run. 
+
+Finally, a template skillet is executed that outputs a **Workflow Completed** message, so the user is 
+clear about the workflow's end. 
+
+
+## Variables
+
+### Main Workflow Menu Options:
+
+* *TARGET_IP*: IP of firewall to validate and configure
+* *TARGET_USERNAME*: Username of firewall management user
+* *TARGET_PASSWORD*: Password of the above user
+* *edl_url*: URL used for the External Dynamic List
+* *assess_options*: Checkbox for validation skillet execution orders (beginning and/or 
+  end of the workflow)
+
+### Configuration Sub-Skillet Options:
+
+* *tag_name*: Name of a newly created tag that is used in the security rules
+* *tag_description*: Text field to describe the tag
+* *tag_color*: Dropdown menu mapping color names to color numbers (required in the XML configuration)
+
+* *edl_name*: Name of the newly created External Dynamic List
+* *edl_description*: Text field used to describe the External Dynamic List
+
+The 'recurring' value for the EDL is set to *five-minutes*. This could be added as a variable but for this example, the
 value is considered a recommended practice so not configurable in the skillet.
 
 The EDL type is set to IP since used in the security policy and is not configurable in the skillet.
 
-## security policy referencing variables
+### Configuration Sub-Skillet Security Policy Referencing Variables
 
 The security policy does not have its own variables asking for rule name, zones, or actions. The rules are
 hardcoded with 'any' for most attributes and action as _deny_ to block traffic matching the EDL IP list.

--- a/sample_workflow_skillet/README.md
+++ b/sample_workflow_skillet/README.md
@@ -1,6 +1,7 @@
 # Sample Workflow Skillet
 
-This is used in the training material as part of the Workflow tutorial.
+This is used in the training material as part of the SkilletBuilder
+[Workflow tutorial](https://skilletbuilder.readthedocs.io/en/latest/tutorials/tutorial_workflow.html).
 
 The solution utilizes three skillets:
 

--- a/sample_workflow_skillet/template_output_report.j2
+++ b/sample_workflow_skillet/template_output_report.j2
@@ -7,6 +7,7 @@ the configuration of the NGFW ({{ TARGET_IP }}). In addition, security policies 
 were configured to deny traffic to and from this EDL.
 <br/>
 <br/>
-For a step-by-step tutorial on building workflows, please navigate to the <a href="">Workflow Tutorial</a>
+For a step-by-step tutorial on building workflows, please navigate to the
+<a href="https://skilletbuilder.readthedocs.io/en/latest/tutorials/tutorial_workflow.html">Workflow Tutorial</a>
 in the SkilletBuilder documentation.
 </div>


### PR DESCRIPTION
## Description

- Updated the README to pertain more to the workflow skillet instead of the old configuration skillet.
- Fixed the empty/broken link in the template skillet of the workflow tutorial that now points to the tutorial documentation.

## Motivation and Context

There was an empty/broken link in the README and template skillet for the workflow tutorial documentation home page.

## How Has This Been Tested?

Tested the template skillet link after running the workflow skillet in my local instance of PanHandler.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
