### PR TITLE
Added SLI Tutorial Video to Set Commands Tutorial

### DIFF
--- a/docs/tutorials/tutorial_set_commands.rst
+++ b/docs/tutorials/tutorial_set_commands.rst
@@ -28,6 +28,16 @@ used as a complement to the documentation content.
     e9138&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405"
     width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
 
+The video below provides an end-to-end perspective for getting a configuration difference in set command format, saving
+the config diff to a file and then using the SLI utility tool to load it into an NGFW.
+
+.. raw:: html
+
+    <iframe src="https://paloaltonetworks.hosted.panopto.com/Panopto/Pages/Embed.aspx?id=85ec045b-9ef8-4bd3-902a-ad49016
+    5825c&autoplay=false&offerviewer=true&showtitle=true&showbrand=false&start=0&interactivity=all" height="405"
+    width="720" style="border: 1px solid #464646;" allowfullscreen allow="autoplay"></iframe>
+
+
 Navigation Menu
 ~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Description

Took and added the SLI portion of the tutorial videos to the set commands tutorial.

## How Has This Been Tested?

Tested these changes locally by running `make html` and viewing the web html version of my changes. They worked, the panopto video just needs to be accepted into the public space.

## Screenshots (if appropriate)

<img width="744" alt="Screen Shot 2021-06-16 at 2 56 44 PM" src="https://user-images.githubusercontent.com/38056262/122299618-12836180-ceb3-11eb-9cd9-4a8e6d2dde56.png">

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
