### PR TITLE
Changed GitLab reference in tutorial_set_commands.rst File

### DIFF
--- a/docs/tutorials/tutorial_set_commands.rst
+++ b/docs/tutorials/tutorial_set_commands.rst
@@ -464,7 +464,7 @@ Using SLI to Perform a Configuration Difference
       
     At this point all configurations should have been made in your NGFW, simply log in to validate and commit the changes in your NGFW.
 
-.. _`SLI documentation`: https://gitlab.com/panw-gse/as/sli
+.. _`SLI documentation`: https://pypi.org/project/sli/
 
 
 Test and Troubleshoot


### PR DESCRIPTION
## Description

Changed a GitLab reference in the tutorial_set_commands.rst File for skillet builder. The SLI reference now points to PyPi instead of GitLab.

## Motivation and Context

Change is required for gitlab/github revamp efforts. Looking to change GitLab to be private and GitHub to be all public so we can have SSO 2-fact set up.

## How Has This Been Tested?

Ran `make html` and tested the changes locally. Looked fine.
